### PR TITLE
Bug fix: Extract css rule error to a new let statement

### DIFF
--- a/rosin-core/src/css/stylesheet.rs
+++ b/rosin-core/src/css/stylesheet.rs
@@ -221,7 +221,8 @@ impl Stylesheet {
                     }
                 }
                 Err((error, css)) => {
-                    let msg = format_args!("Failed to parse CSS rule: `{}`", css.lines().next().unwrap_or(""));
+                    let rule = css.lines().next().unwrap_or("");
+                    let msg = format_args!("Failed to parse CSS rule: `{}`", rule);
                     css::log_error(msg, error.location, file_name);
                 }
             }


### PR DESCRIPTION
When trying to compile this on macos to look at the examples, there was an error preventing this:
<img width="1834" height="466" alt="image" src="https://github.com/user-attachments/assets/617b0174-7075-4496-9e6e-48f229464232" />

This was a pretty simple fix, and afterwards the library can compile and runs the examples well.